### PR TITLE
Reduce image size, update base image for node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bookworm
 
 WORKDIR /opt/app-root/
 ENV PATH=/opt/app-root/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11-bookworm
+FROM python:3.11-slim-bookworm
 
 WORKDIR /opt/app-root/
 ENV PATH=/opt/app-root/bin:$PATH
 
 # Create python virtual environment for installing required packages
 RUN apt-get update && \
-    apt-get install -y git nodejs npm && \
+    apt-get install -y wget git nodejs npm && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     /usr/local/bin/python -m venv /opt/app-root/ && \


### PR DESCRIPTION
With the jump from buster to bookworm, the image size increased from 1.7GB to 2.07GB, so moved to the slim-bookworm base image and reduced the size back down to 1.65GB. Slim base image required the additional install of wget, but no other changes were necessary.